### PR TITLE
Add option to use in-memory db instead of sql server

### DIFF
--- a/PocketDDD.Server/PocketDDD.Server.WebAPI/PocketDDD.Server.WebAPI.csproj
+++ b/PocketDDD.Server/PocketDDD.Server.WebAPI/PocketDDD.Server.WebAPI.csproj
@@ -12,6 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.15" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/PocketDDD.Server/PocketDDD.Server.WebAPI/Program.cs
+++ b/PocketDDD.Server/PocketDDD.Server.WebAPI/Program.cs
@@ -24,8 +24,13 @@ builder.Services.AddCors(options =>
     });
 });
 
-builder.Services.AddDbContext<PocketDDDContext>(
-    options => options.UseSqlServer("name=ConnectionStrings:PocketDDDContext"));
+if (builder.Configuration.GetValue<bool>("InMemoryDatabase"))
+    builder.Services.AddDbContext<PocketDDDContext>(
+        options => options.UseInMemoryDatabase("InMemoryDatabase"));
+else
+    builder.Services.AddDbContext<PocketDDDContext>(
+        options => options.UseSqlServer("name=ConnectionStrings:PocketDDDContext"));
+
 
 builder.Services.AddScoped<RegistrationService>();
 builder.Services.AddScoped<UserService>();


### PR DESCRIPTION
Useful for tests!

- Open a terminal in `PocketDDD.Server/PocketDDD.Server.WebAPI/`
- Run `dotnet user-secrets set "InMemoryDatabase" true`
- Now whenever you run the API (using `dotnet run`) it will create a brand new "fake" database in memory which is completely empty